### PR TITLE
Fixing issue with Blindness and Generator Initializing

### DIFF
--- a/epioncho_ibm/advance/advance.py
+++ b/epioncho_ibm/advance/advance.py
@@ -136,14 +136,17 @@ def advance_state(state: State, debug: bool = False) -> None:
     )
 
     new_has_sequela = {}
+    _, new_measured_mf = state.microfilariae_per_skin_snip()
+    new_rounded_mf: Array.Person.Float = np.round(new_measured_mf)
+    new_total_mf: Array.Person.Float = np.sum(state.people.mf, axis=0)
     for name, old_rel_sequela in state.people.has_sequela.items():
         seq_class = state.derived_params.sequela_classes[name]
         assert name in state.people.countdown_sequela
         rel_seq_countdown = state.people.countdown_sequela[name]
         prob = seq_class.timestep_probability(
             delta_time=state._params.delta_time,
-            true_mf_count=total_mf,
-            measured_mf_count=rounded_mf,
+            true_mf_count=new_total_mf,
+            measured_mf_count=new_rounded_mf,
             ages=old_ages,
             existing_sequela=state.people.has_sequela,
             has_this_sequela=old_rel_sequela,

--- a/epioncho_ibm/state/derived_params.py
+++ b/epioncho_ibm/state/derived_params.py
@@ -33,9 +33,12 @@ class DerivedParams:
     worm_sex_ratio_generator: Generator
     worm_lambda_zero_generator: Generator
     worm_omega_generator: Generator
+    worm_mortality_generator: Generator
     sequela_classes: dict[str, type[Sequela]]
 
-    def __init__(self, params: Params) -> None:
+    def __init__(
+        self, params: Params, oldGenerators: dict[str, Generator] = None
+    ) -> None:
         worm_age_categories: Array.WormCat.Float = np.arange(
             start=0,
             stop=params.worms.max_worm_age,
@@ -84,26 +87,37 @@ class DerivedParams:
         else:
             self.treatment_times = None
 
-        seeds = [
-            params.seed + i + 1 if params.seed is not None else None for i in range(6)
-        ]
-        self.people_to_die_generator = Generator(
-            SFC64(seeds[0]), params.delta_time / params.humans.mean_human_age
-        )
-        self.worm_age_rate_generator = Generator(
-            SFC64(seeds[1]), params.delta_time / params.worms.worms_aging
-        )
-        self.worm_sex_ratio_generator = Generator(
-            SFC64(seeds[2]), params.worms.sex_ratio
-        )
-        self.worm_lambda_zero_generator = Generator(
-            SFC64(seeds[3]), params.worms.lambda_zero * params.delta_time
-        )
-        self.worm_omega_generator = Generator(
-            SFC64(seeds[4]), params.worms.omega * params.delta_time
-        )
-        self.worm_mortality_generator = Generator(
-            SFC64(seeds[5]), self.worm_mortality_rate
-        )
+        if oldGenerators is None:
+            seeds = [
+                params.seed + i + 1 if params.seed is not None else None
+                for i in range(6)
+            ]
+            self.people_to_die_generator = Generator(
+                SFC64(seeds[0]), params.delta_time / params.humans.mean_human_age
+            )
+            self.worm_age_rate_generator = Generator(
+                SFC64(seeds[1]), params.delta_time / params.worms.worms_aging
+            )
+            self.worm_sex_ratio_generator = Generator(
+                SFC64(seeds[2]), params.worms.sex_ratio
+            )
+            self.worm_lambda_zero_generator = Generator(
+                SFC64(seeds[3]), params.worms.lambda_zero * params.delta_time
+            )
+            self.worm_omega_generator = Generator(
+                SFC64(seeds[4]), params.worms.omega * params.delta_time
+            )
+            self.worm_mortality_generator = Generator(
+                SFC64(seeds[5]), self.worm_mortality_rate
+            )
+        else:
+            self.people_to_die_generator = oldGenerators["people_to_die_generator"]
+            self.worm_age_rate_generator = oldGenerators["worm_age_rate_generator"]
+            self.worm_sex_ratio_generator = oldGenerators["worm_sex_ratio_generator"]
+            self.worm_lambda_zero_generator = oldGenerators[
+                "worm_lambda_zero_generator"
+            ]
+            self.worm_omega_generator = oldGenerators["worm_omega_generator"]
+            self.worm_mortality_generator = oldGenerators["worm_mortality_generator"]
 
         self.sequela_classes = get_sequela(params.sequela_active)


### PR DESCRIPTION
When running some simulations to look at the sequelae, a new issue was found with Blindness prevalence, where the prevalence would increase whenever we started MDA (graphs on the right). In digging deeper, this seemed to me like something happening when the MDA was applied, not necessarily specific to blindness. I found that right after MDA was applied (i.e parameters were changed), the age distribution seemed to completely break. In the graphs on the left, the y axis is the number of people in each age group, with the red line being the first year of MDA. You can see that the number of people in the younger age groups drastically drops after MDA is applied, whereas the older age groups increase.

Population Count             |  Blindness Prev
:-------------------------:|:-------------------------:
![testing_blindness_sequelae_CIV0162715440_start1800_50_sample_mda_broken_population](https://github.com/NTD-Modelling-Consortium/EPIONCHO-IBM/assets/25516345/c2581b7e-e45f-4b40-9ddd-225c0297c82b)  |  ![testing_blindness_sequelae_CIV0162715440_start1800_50_sample_mda_broken](https://github.com/NTD-Modelling-Consortium/EPIONCHO-IBM/assets/25516345/7edb8900-a179-42d9-8154-cfdb4b9c9c00)


These changes made it seem like something was broken with the random number generators, possibly because they were being re-initialized with the same seed. This fix will make sure that the random number generators will only be re-created if the seed changes.

There is also another change to use the newly updated MF intensity values when calculating sequela, rather than the old values. This is a slight change, and shouldn't cause any major issues. 
Below is the above graphs with the new changes.

Population Count             |  Blindness Prev
:-------------------------:|:-------------------------:
![testing_blindness_sequelae_CIV0162715440_start1800_50_sample_mda_no_recreate_generator_population](https://github.com/NTD-Modelling-Consortium/EPIONCHO-IBM/assets/25516345/ad7d4620-31d3-4152-977b-1ffe9589781b) |  ![testing_blindness_sequelae_CIV0162715440_start1800_50_sample_mda_no_recreate_generator](https://github.com/NTD-Modelling-Consortium/EPIONCHO-IBM/assets/25516345/1b15d2ea-d771-4c0c-930d-bb5d1f623ffa)