### PR TITLE
Fixing the exposure functions, switch to using a ratio (Q) as an input for the sex-specifc exposure

### DIFF
--- a/epioncho_ibm/advance/advance.py
+++ b/epioncho_ibm/advance/advance.py
@@ -36,6 +36,7 @@ def advance_state(state: State, debug: bool = False) -> None:
 
     total_exposure = calculate_total_exposure(
         state._params.exposure,
+        state._params.humans.gender_ratio,
         state.people.ages,
         state.people.sex_is_male,
         state.people.individual_exposure,

--- a/epioncho_ibm/state/params.py
+++ b/epioncho_ibm/state/params.py
@@ -111,8 +111,7 @@ class MicrofilParams(BaseModel):
 
 class ExposureParams(BaseModel):
     # age-dependent exposure to fly bites
-    male_exposure: float = 1.08  # "m.exp"
-    female_exposure: float = 0.9  # "f.exp"
+    Q: float = 1.2  # "Em/Ef"
     male_exposure_exponent: float = 0.007  # "age.exp.m"
     female_exposure_exponent: float = -0.023  # "age.exp.f"
 


### PR DESCRIPTION
The exposure function previously used did not properly incorporate the sex-specifc exposure.
There were two issues.
1) It normalized the age exposures incorrectly (setting gamma.s = 1/mean(E.s*e^(alpha.s*age))) when it should have been gamma.s = 1/mean(e^alpha.s*age).

Additionally, the sex-specific exposures were able to be set individually for each sex, when they should have been derived from an exposure ratio (Q), and the gender ratio. 

These have been fixed in the following PR, extending a new exposure parameter "Q", and removing "male_exposure" and "female_exposure"

The math for the equations can be seen in the attachment [EPIONCHO-IBM age and sex structure.docx](https://github.com/NTD-Modelling-Consortium/EPIONCHO-IBM/files/14531903/EPIONCHO-IBM.age.and.sex.structure.docx). These have been derived from the following paper: https://www.pnas.org/doi/full/10.1073/pnas.0502659102#tbl1.


I have tested the changes, and was able to create a graph that resembles previous runs of this model.
![comparison_plot_new](https://github.com/NTD-Modelling-Consortium/EPIONCHO-IBM/assets/25516345/1249f14b-b3e9-44cc-8cde-028b69042c26)
