### PR TITLE
Simplifying MDA Intervention times and updating the N treatment output

### DIFF
--- a/epioncho_ibm/advance/advance.py
+++ b/epioncho_ibm/advance/advance.py
@@ -29,9 +29,13 @@ def advance_state(state: State, debug: bool = False) -> None:
         assert state.n_treatments is not None
         n_treatments_by_age, _ = np.histogram(
             state.people.ages[treatment.coverage_in],
-            bins=len(state.n_treatments),
+            bins=np.arange(0, state._params.humans.max_human_age + 1),
         )
-        state.n_treatments += n_treatments_by_age
+
+        treatment_name_val = str(state._params.treatment.treatment_name) + " MDA Round"
+        state.n_treatments[
+            (state.current_time, treatment_name_val)
+        ] = n_treatments_by_age
         state.people.has_been_treated = (
             state.people.has_been_treated | treatment.coverage_in
         )

--- a/epioncho_ibm/advance/advance.py
+++ b/epioncho_ibm/advance/advance.py
@@ -19,11 +19,13 @@ def advance_state(state: State, debug: bool = False) -> None:
         state._params.delta_time,
         state.current_time,
         state.derived_params.treatment_times,
+        state.derived_params.treatment_index,
         state.people.ages,
         state.people.compliance,
         state.numpy_bit_generator,
     )
     if treatment is not None and treatment.treatment_occurred:
+        state.derived_params.treatment_index += 1
         assert state.n_treatments is not None
         n_treatments_by_age, _ = np.histogram(
             state.people.ages[treatment.coverage_in],

--- a/epioncho_ibm/advance/treatment.py
+++ b/epioncho_ibm/advance/treatment.py
@@ -12,6 +12,7 @@ def _is_during_treatment(
     current_time: float,
     delta_time: float,
     treatment_times: Optional[Array.Treatments.Float],
+    treatment_index: Optional[float],
 ) -> tuple[bool, bool]:
     """
     Returns two booleans describing if treatment has started, and if it occurred.
@@ -27,19 +28,12 @@ def _is_during_treatment(
             bool describing if treatment occurred, respectively
     """
     treatment_started = current_time >= treatment.start_time
+    treatment_occurred: bool = False
     if treatment_started:
         assert treatment_times is not None
-        treatment_occurred: bool = (
-            bool(
-                np.any(
-                    (treatment_times <= current_time)
-                    & (treatment_times > current_time - delta_time)
-                )
-            )
-            and current_time <= treatment.stop_time
-        )
-    else:
-        treatment_occurred = False
+        if treatment_index < len(treatment_times):
+            next_treatment_time = treatment_times[treatment_index]
+            treatment_occurred = current_time - next_treatment_time >= 0
     return treatment_started, treatment_occurred
 
 
@@ -63,6 +57,7 @@ def get_treatment(
     delta_time: float,
     current_time: float,
     treatment_times: Optional[Array.Treatments.Float],
+    treatment_index: Optional[float],
     ages: Array.Person.Float,
     compliance: Optional[Array.Person.Float],
     numpy_bit_gen: Generator,
@@ -91,6 +86,7 @@ def get_treatment(
             current_time,
             delta_time,
             treatment_times,
+            treatment_index,
         )
         if treatment_started:
             rand_nums = numpy_bit_gen.uniform(low=0, high=1, size=len(ages))

--- a/epioncho_ibm/endgame_simulation.py
+++ b/epioncho_ibm/endgame_simulation.py
@@ -110,9 +110,9 @@ def endgame_to_params(endgame: EpionchoEndgameModel) -> list[tuple[float, Params
             program = next(programs)
 
             assert not isinstance(program.interventions, list)
-
             treatment_dict = program.interventions.dict()
             interval_years = treatment_dict.pop("treatment_interval")
+            treatment_name = treatment_dict.pop("treatment_name")
             treatment = TreatmentParams(
                 **treatment_dict,
                 interval_years=interval_years,
@@ -120,6 +120,7 @@ def endgame_to_params(endgame: EpionchoEndgameModel) -> list[tuple[float, Params
                 stop_time=_time_from_year_and_month(
                     program.last_year, program.last_month, is_last=True
                 ),
+                treatment_name=treatment_name,
             )
 
             if current_params.time != time_of_change:

--- a/epioncho_ibm/state/derived_params.py
+++ b/epioncho_ibm/state/derived_params.py
@@ -1,4 +1,3 @@
-import math
 from typing import Optional
 
 import numpy as np
@@ -28,6 +27,7 @@ class DerivedParams:
     fecundity_rates_worms: Array.WormCat.Float
     microfillarie_mortality_rate: Array.MFCat.Float
     treatment_times: Optional[Array.Treatments.Float]
+    treatment_index: Optional[float]
     people_to_die_generator: Generator
     worm_age_rate_generator: Generator
     worm_sex_ratio_generator: Generator
@@ -37,7 +37,10 @@ class DerivedParams:
     sequela_classes: dict[str, type[Sequela]]
 
     def __init__(
-        self, params: Params, oldGenerators: dict[str, Generator] = None
+        self,
+        params: Params,
+        current_time: float,
+        oldGenerators: dict[str, Generator] = None,
     ) -> None:
         worm_age_categories: Array.WormCat.Float = np.arange(
             start=0,
@@ -71,21 +74,15 @@ class DerivedParams:
             microfillarie_age_categories,
         )
         if params.treatment is not None:
-            treatment_number = (
-                params.treatment.stop_time - params.treatment.start_time
-            ) / params.treatment.interval_years
-            if round(treatment_number) != round(treatment_number, 10):
-                raise ValueError(
-                    f"Treatment times could not be found for start: {params.treatment.start_time}, stop: {params.treatment.stop_time}, interval: {params.treatment.interval_years}"
-                )
-            treatment_number_int: int = math.ceil(treatment_number)
-            self.treatment_times = np.linspace(
-                start=params.treatment.start_time,
+            self.treatment_times = np.arange(
+                start=params.treatment.start_time + params.delta_time,
                 stop=params.treatment.stop_time,
-                num=treatment_number_int + 1,
+                step=params.treatment.interval_years,
             )
+            self.treatment_index = np.where(self.treatment_times >= current_time)[0][0]
         else:
             self.treatment_times = None
+            self.treatment_index = 0
 
         if oldGenerators is None:
             seeds = [

--- a/epioncho_ibm/state/derived_params.py
+++ b/epioncho_ibm/state/derived_params.py
@@ -79,7 +79,10 @@ class DerivedParams:
                 stop=params.treatment.stop_time,
                 step=params.treatment.interval_years,
             )
-            self.treatment_index = np.where(self.treatment_times >= current_time)[0][0]
+            possible_indeces = np.where(self.treatment_times >= current_time)[0]
+            self.treatment_index = (
+                possible_indeces[0] if len(possible_indeces) > 0 else 0
+            )
         else:
             self.treatment_times = None
             self.treatment_index = 0

--- a/epioncho_ibm/state/params.py
+++ b/epioncho_ibm/state/params.py
@@ -31,6 +31,7 @@ class TreatmentParams(SpecificTreatmentParams):
     interval_years: float = 1  # treatment interval (years, 0.5 gives biannual)
     start_time: float  # The iteration upon which treatment commences
     stop_time: float  # the iteration upon which treatment stops
+    treatment_name: str = "IVM"
 
 
 class WormParams(BaseModel):

--- a/epioncho_ibm/state/state.py
+++ b/epioncho_ibm/state/state.py
@@ -200,6 +200,10 @@ class State(HDF5Dataclass, BaseState[Params]):
                 self.numpy_bit_generator,
             )
 
+        # backwards compatibility check, where n_treatments used to be an array, instead of a dict
+        if not isinstance(self.n_treatments, dict):
+            self.n_treatments = {}
+
         oldGenerators = None
         # brute force - if one generator is initialized, we expect all of them to be initialized
         if (self._params.seed == params.seed) and (
@@ -437,7 +441,9 @@ class State(HDF5Dataclass, BaseState[Params]):
             else self._params.treatment.min_age_of_treatment
         )
         eligible_population = self.people.ages >= min_age
-        return 1 - np.mean(self.people.has_been_treated[eligible_population])
+        if np.sum(eligible_population) > 0:
+            return 1 - np.mean(self.people.has_been_treated[eligible_population])
+        return 1
 
 
 def make_state_from_params(params: Params):

--- a/epioncho_ibm/state/state.py
+++ b/epioncho_ibm/state/state.py
@@ -220,7 +220,7 @@ class State(HDF5Dataclass, BaseState[Params]):
     def _derive_params(self, oldGenerators) -> None:
         assert self._params
         self.derived_params = DerivedParams(
-            immutable_to_mutable(self._params), oldGenerators
+            immutable_to_mutable(self._params), self.current_time, oldGenerators
         )
 
     def get_state_for_age_group(self, age_start: float, age_end: float) -> "State":

--- a/epioncho_ibm/state/state.py
+++ b/epioncho_ibm/state/state.py
@@ -1,5 +1,4 @@
 from dataclasses import field
-from math import ceil
 from pathlib import Path
 from typing import IO, Callable, Optional, overload
 
@@ -148,7 +147,7 @@ def get_OAE_mf_count_func(mf: list[int], prob: list[float], val_for_0: float):
 class State(HDF5Dataclass, BaseState[Params]):
     people: People
     _params: ImmutableParams
-    n_treatments: Optional[Array.General.Int]
+    n_treatments: Optional[dict[float, Array.General.Int]]
     current_time: float = 0.0
     _previous_delta_time: Optional[float] = None
     derived_params: DerivedParams = field(init=False, repr=False)
@@ -229,7 +228,10 @@ class State(HDF5Dataclass, BaseState[Params]):
             _params=self._params,
             current_time=self.current_time,
             _previous_delta_time=self._previous_delta_time,
-            n_treatments=None,
+            n_treatments={
+                key: value[age_start:age_end]
+                for key, value in self.n_treatments.items()
+            },
         )
 
     @classmethod
@@ -252,10 +254,7 @@ class State(HDF5Dataclass, BaseState[Params]):
             _params=mutable_to_immutable(params),
             current_time=current_time,
             _previous_delta_time=None,
-            n_treatments=np.zeros(
-                round(params.humans.max_human_age / params.n_treatments_bin_size),
-                dtype=int,
-            ),
+            n_treatments={},
         )
 
     def __eq__(self, other: object) -> bool:
@@ -268,21 +267,20 @@ class State(HDF5Dataclass, BaseState[Params]):
         )
 
     def reset_treatment_counter(self):
-        if self.n_treatments is None:
-            raise ValueError("Cannot reset treatment count for state age sub group")
-        self.n_treatments.fill(0)
+        self.n_treatments = {}
 
     def get_treatment_count_for_age_group(
         self, age_start: float, age_end: float
     ) -> int:
         if age_start > age_end:
             raise ValueError(f"Age start {age_start} > age end {age_end}")
-        start_idx: int = int(age_start // self._params.n_treatments_bin_size)
-        end_idx: int = ceil(age_end / self._params.n_treatments_bin_size)
 
         if self.n_treatments is None:
             raise ValueError("Cannot get treatment count for state age sub group")
-        return self.n_treatments[start_idx:end_idx].sum()
+        return {
+            key: np.nansum(value[age_start:age_end])
+            for key, value in self.n_treatments.items()
+        }
 
     def stats(self) -> StateStats:
         if self.people.compliance is not None:

--- a/epioncho_ibm/tools.py
+++ b/epioncho_ibm/tools.py
@@ -1,4 +1,5 @@
 import csv
+import math
 from collections import defaultdict
 
 from epioncho_ibm import State
@@ -100,7 +101,7 @@ def add_state_to_run_data(
                     )
 
                     partial_key = (
-                        round(time_of_intervention, 2),
+                        math.floor(time_of_intervention),
                         age_start,
                         age_start + 1,
                     )
@@ -133,7 +134,7 @@ def add_state_to_run_data(
                     number_of_rounds.get(intervention_type, 0) + 1
                 )
 
-                partial_key = (round(time_of_intervention, 2), age_min, age_max)
+                partial_key = (math.floor(time_of_intervention), age_min, age_max)
                 if n_treatments:
                     run_data[
                         (


### PR DESCRIPTION
**Fix To MDA Intervention Time steps**
- Similar to one of the changes in [this PR](https://github.com/NTD-Modelling-Consortium/endgame-simulations/pull/15), the MDA calculation should not be based upon any calculation with delta time, as that introduces a lot of imprecision, and has resulted in many of the issues we faced in the past. 
- Instead, we utilize a similar method as to the sampling years, where we create a list of MDA application times using the interval provided. Then, at the first time point that is >= that value, we apply MDA. The location of the next MDA time is stored via an indexer
  - If we update a different parameter before MDA has finished, this causes the array and index to reset. The MDA start time and stop time are kept the same, so the array has the same values as previously, however we need to make sure the index is in the right spot. To do this, we just check for the first MDA time that is >= the current time, and set the index there.

**New Output**
- As was requested, we now output the number of doses that were applied in each MDA round. A "dose" is just an individual being treated in a given round. These are output as "[Intervention name] MDA Round [Round Number]". The [intervention name] is taken from a new parameter in the TreatmentParams class, with the default being "IVM". The [Round Number] is calculated during output (as described below)
  - **Note, this does modify the previous output of n_treatments**
  - In the model, once MDA application has taken place, we store both the timestep and the related number of doses per age group into a dictionary. Upon an output happening, loop through all the times in the dictionary, and add their MDA results to the output (by age group, or as a total). Once this has been done, the dictionary is reset, so as to only display MDA rounds since the previous output. 
  - One optional parameter has been added to `add_state_to_run_data`, `saving_multiple_states` (default = False). If the use case was to capture outputs with both age grouped AND all age, the first call to `add_state_to_run_data`, will result in the dictionary being reset before the second call to `add_state_to_run_data`, meaning the MDA rounds will only be displayed in one of the two outputs. To fix this, we can set `saving_multiple_states` to True in the first call to `add_state_to_run_data`, which will NOT reset the dictionary containing MDA rounds. The second call to `add_state_to_run_data` can have `saving_multiple_states` set as False, which will then reset the dictionary as intended.
  
  **Other Minor Fixes**
- Adding a logic check to the PNC calculation to remove the empty slice warning from numpy if there is no eligible population (mainly occurs when outputting for an age group that is < than the minimum age of treatment).

![comparison_plot_new_compare_with_hdf5](https://github.com/NTD-Modelling-Consortium/EPIONCHO-IBM/assets/25516345/fbe64364-e404-458a-b0df-d08726457ed2)

![comparison_plot_new_hdf5](https://github.com/NTD-Modelling-Consortium/EPIONCHO-IBM/assets/25516345/a8cca46b-fddf-46b1-b638-7793512fb0af)




