### PR TITLE
Changing dictionary key to be a string instead of a tuple to account for the hdf5 save functionality

### DIFF
--- a/epioncho_ibm/advance/advance.py
+++ b/epioncho_ibm/advance/advance.py
@@ -38,10 +38,10 @@ def advance_state(state: State, debug: bool = False) -> None:
 
         treatment_name_val = str(state._params.treatment.treatment_name) + " MDA Round"
         state.n_treatments[
-            (state.current_time, treatment_name_val)
+            str(state.current_time) + "," + str(treatment_name_val)
         ] = n_treatments_by_age
         state.n_treatments_population[
-            (state.current_time, treatment_name_val)
+            str(state.current_time) + "," + str(treatment_name_val)
         ] = n_people_by_age
 
         state.people.has_been_treated = (

--- a/epioncho_ibm/tools.py
+++ b/epioncho_ibm/tools.py
@@ -94,8 +94,8 @@ def add_state_to_run_data(
                     )
                     number_of_rounds = {}
                     for key, value in sorted(n_treatments_val.items()):
-                        time_of_intervention = key[0]
-                        intervention_type = key[1]
+                        time_of_intervention = float(key.split(",")[0])
+                        intervention_type = key.split(",")[1]
                         number_of_rounds[intervention_type] = (
                             number_of_rounds.get(intervention_type, 0) + 1
                         )
@@ -121,8 +121,8 @@ def add_state_to_run_data(
                     )
                     number_of_rounds = {}
                     for key, value in sorted(achieved_coverage_val.items()):
-                        time_of_intervention = key[0]
-                        intervention_type = key[1]
+                        time_of_intervention = float(key.split(",")[0])
+                        intervention_type = key.split(",")[1]
                         number_of_rounds[intervention_type] = (
                             number_of_rounds.get(intervention_type, 0) + 1
                         )
@@ -149,8 +149,8 @@ def add_state_to_run_data(
                 )
                 number_of_rounds = {}
                 for key, value in sorted(n_treatments_val.items()):
-                    time_of_intervention = key[0]
-                    intervention_type = key[1]
+                    time_of_intervention = float(key.split(",")[0])
+                    intervention_type = key.split(",")[1]
 
                     number_of_rounds[intervention_type] = (
                         number_of_rounds.get(intervention_type, 0) + 1
@@ -172,8 +172,8 @@ def add_state_to_run_data(
                 )
                 number_of_rounds = {}
                 for key, value in sorted(achieved_coverage_val.items()):
-                    time_of_intervention = key[0]
-                    intervention_type = key[1]
+                    time_of_intervention = float(key.split(",")[0])
+                    intervention_type = key.split(",")[1]
                     number_of_rounds[intervention_type] = (
                         number_of_rounds.get(intervention_type, 0) + 1
                     )


### PR DESCRIPTION
Using a tuple as the dictionary key was causing a type error when calling the `.to_hdf5()` function when saving a simulation. I have converted the key to a comma delimited string, and then split the string in tools.py to extract the values.