### PR TITLE
Removing the normalization of the inter-individual heterogeneity

### DIFF
--- a/epioncho_ibm/advance/exposure.py
+++ b/epioncho_ibm/advance/exposure.py
@@ -59,7 +59,5 @@ def calculate_total_exposure(
         female_exposure_array,
     )
 
-    normalized_individual_exposure = individual_exposure / np.mean(individual_exposure)
-
-    total_exposure = sex_age_exposure * normalized_individual_exposure
+    total_exposure = sex_age_exposure * individual_exposure
     return total_exposure / np.mean(total_exposure)


### PR DESCRIPTION
After testing and discussion, we thought that normalizing the exposure heterogeneity is counter-intuitive, as it would result in the value for all alive individuals being slightly adjusted with a death (due to re-normalization).  Tested previous outputs with and without this, which resulted in no-change to MFP. However, this change might add a little more variability with the nested model testing, and refitting ABRs.

![image](https://github.com/NTD-Modelling-Consortium/EPIONCHO-IBM/assets/25516345/44eb8aab-1ffb-46be-a0f3-6cff6830ba64)
