### PR TITLE
Fixing backwards compatibility bug

### DIFF
--- a/epioncho_ibm/state/people.py
+++ b/epioncho_ibm/state/people.py
@@ -250,7 +250,7 @@ class People(HDF5Dataclass):
     age_test_OAE: Array.Person.Float
     has_sequela: dict[str, Array.Person.Bool]
     countdown_sequela: dict[str, Array.Person.Float]
-    has_been_treated: Array.Person.Bool
+    has_been_treated: Optional[Array.Person.Bool]
 
     def __eq__(self, other: object) -> bool:
         if isinstance(other, People):

--- a/epioncho_ibm/state/state.py
+++ b/epioncho_ibm/state/state.py
@@ -206,6 +206,10 @@ class State(HDF5Dataclass, BaseState[Params]):
             self.n_treatments = {}
             self.n_treatments_population = {}
 
+        # backwards compatibility check, where people.has_been_treated did not exist
+        if self.people.has_been_treated is None:
+            self.people.has_been_treated = np.full(params.n_people, False)
+
         oldGenerators = None
         # brute force - if one generator is initialized, we expect all of them to be initialized
         if (self._params.seed == params.seed) and (


### PR DESCRIPTION
Fixing an issue when using previous versions of the model where `has_been_treated` didn't exist. This makes it an optional variable, and sets it by default to all False if it doesn't exist.