### PR TITLE
Adding Immigration Functionality

### DIFF
--- a/epioncho_ibm/advance/advance.py
+++ b/epioncho_ibm/advance/advance.py
@@ -55,6 +55,13 @@ def advance_state(state: State, debug: bool = False) -> None:
         state.people.sex_is_male,
         state.people.individual_exposure,
     )
+
+    state.people.immigration_check(
+        state._params.blackfly,
+        state._params.immigration_rate,
+        state._params.delta_time,
+        state.derived_params.worm_sex_ratio_generator,
+    )
     old_ages = state.people.ages.copy()
     state.people.ages += state._params.delta_time
 

--- a/epioncho_ibm/state/params.py
+++ b/epioncho_ibm/state/params.py
@@ -94,6 +94,10 @@ class BlackflyParams(BaseModel):
     l1_delay: float = 4  # (days)
     l3_delay: float = 10  # "l3.delay" (months) delay in worms entering humans and joining the first adult worm age class
 
+    immigrated_worm_count: int = (
+        0  # The number of worms that immigrated individuals will start with
+    )
+
 
 class MicrofilParams(BaseModel):
     microfil_move_rate: float = 8.13333  # 'mf.move.rate' #for aging in parasites
@@ -137,6 +141,9 @@ class BaseParams(BaseModel):
     year_length_days: float = 365
     month_length_days: float = 28
     sequela_active: SequelaType = []
+    immigration_rate: float = (
+        0  # The yearly rate at which people immigrate into the population
+    )
 
 
 class BaseMutableParams(BaseParams):


### PR DESCRIPTION
Adding an "immigration" to the model.

The general implementation aims to capture immigration by replace the worm burden of individuals in a population with a new value. 


There are 2 parameters. `immigration_rate` which is under the “Initial” parameters, and `immigrated_worm_count` which is under the blackfly parameters. Immigration rate defines a value for the proportion of the population that we expect to immigrate every year, captures as a value between 0 and 1 (I will define the priors below). This is translated to a “daily” rate using the following formula
daily probability of immigration = (1 - (1 - immigration_rate)^delta_time), 
where delta time is the timestep (typically 1/365)

Immigrated Worm Count defines the worm burden for an individual who is immigrating into the population, and can only be whole numbers. We use this number as the total number of worms, and then use a binomial distribution to determine the sex of the worms. Female worms will be automatically considered as fertile female worms.
