### PR TITLE
Fix invalid test for unequal distribution of treatment times

### DIFF
--- a/tests/epioncho_tests/state/test_derived_params.py
+++ b/tests/epioncho_tests/state/test_derived_params.py
@@ -1,0 +1,13 @@
+from epioncho_ibm.state.derived_params import DerivedParams
+from epioncho_ibm.state.params import Params, TreatmentParams
+
+
+def test_treatment_times_uneven_spacing():
+    params = Params(
+        treatment=TreatmentParams(start_time=0, stop_time=10, interval_years=3),
+        n_people=10,
+        delta_time_days=0,
+    )
+    derived_params = DerivedParams(params, current_time=0)
+    assert derived_params.treatment_times is not None
+    assert derived_params.treatment_times.tolist() == [0, 3, 6, 9]

--- a/tests/epioncho_tests/test_errors.py
+++ b/tests/epioncho_tests/test_errors.py
@@ -43,17 +43,3 @@ class TestGeneral:
             match='"ImmutableHumanParams" is immutable and does not support item assignment',
         ):
             simulation.state._params.humans.max_human_age = 80
-
-
-@pytest.mark.asyncio
-class TestDerivedParams:
-    async def test_treament_params_invalid_step(self):
-        with pytest.raises(
-            ValueError,
-            match="Treatment times could not be found for start: 0.0, stop: 10.0, interval: 3.0",
-        ):
-            params = Params(
-                treatment=TreatmentParams(start_time=0, stop_time=10, interval_years=3),
-                n_people=10,
-            )
-            Simulation(start_time=0, params=params)


### PR DESCRIPTION
Currently there is a failing test on master that checks that an error is thrown if the treatment times are not evenly spread out between the start and stop times. However, this is no longer the current behaviour, so this test is pointless. Instead I added a test that tests the current behaviour, which is to spread from the start according to the interval and not worrying if this leaves an uneven gap at the end. 