### PR TITLE
Updating Immigration Functionality to reflect ONCHOSIM a bit more

### DIFF
--- a/epioncho_ibm/advance/advance.py
+++ b/epioncho_ibm/advance/advance.py
@@ -54,14 +54,9 @@ def advance_state(state: State, debug: bool = False) -> None:
         state.people.ages,
         state.people.sex_is_male,
         state.people.individual_exposure,
+        state._params.use_onchosim_mechanisms,
     )
 
-    state.people.immigration_check(
-        state._params.blackfly,
-        state._params.immigration_rate,
-        state._params.delta_time,
-        state.derived_params.worm_sex_ratio_generator,
-    )
     old_ages = state.people.ages.copy()
     state.people.ages += state._params.delta_time
 
@@ -73,6 +68,7 @@ def advance_state(state: State, debug: bool = False) -> None:
         state.people.blackfly.L3,
         state._params.blackfly,
         state._params.delta_time,
+        state._params.use_onchosim_mechanisms,
         total_exposure,
         state.n_people,
         debug,

--- a/epioncho_ibm/advance/blackfly.py
+++ b/epioncho_ibm/advance/blackfly.py
@@ -199,6 +199,7 @@ def calc_new_worms_from_blackfly(
     L3: Array.Person.Float,
     blackfly_params: BlackflyParams,
     delta_time: float,
+    use_onchosim_mechanisms: str,
     total_exposure: Array.Person.Float,
     n_people: int,
     debug: bool,
@@ -219,8 +220,13 @@ def calc_new_worms_from_blackfly(
     Returns:
         Array.Person.Int: The number of new worms produced by L3 larvae
     """
+
+    mean_l3 = float(np.mean(L3))
+    if use_onchosim_mechanisms == "both" or use_onchosim_mechanisms == "immigration":
+        mean_l3 += blackfly_params.immigrated_l3
+
     new_rate = _calc_rate_of_l3_to_worms(
-        blackfly_params, delta_time, float(np.mean(L3)), total_exposure
+        blackfly_params, delta_time, mean_l3, total_exposure
     )
     if debug:
         assert not np.any(new_rate > 10**10)

--- a/epioncho_ibm/advance/exposure.py
+++ b/epioncho_ibm/advance/exposure.py
@@ -9,6 +9,7 @@ def calculate_total_exposure(
     ages: Array.Person.Float,
     sex_is_male: Array.Person.Bool,
     individual_exposure: Array.Person.Float,
+    use_onchosim_mechanisms: str,
 ) -> Array.Person.Float:
     """
     Calculates how much each person is exposed to infection, taking
@@ -53,6 +54,30 @@ def calculate_total_exposure(
         np.logical_not(sex_is_male),
     )
 
+    onchosim_exposure = (
+        use_onchosim_mechanisms == "both" or use_onchosim_mechanisms == "age-sex"
+    )
+    if onchosim_exposure:
+        male_exposure_array = np.where(
+            ages < exposure_params.male_exposure_const_age,
+            ages
+            * (
+                exposure_params.male_exposure_max
+                / exposure_params.male_exposure_const_age
+            ),
+            exposure_params.male_exposure_max,
+        )
+
+        female_exposure_array = np.where(
+            ages < exposure_params.female_exposure_const_age,
+            ages
+            * (
+                exposure_params.female_exposure_max
+                / exposure_params.female_exposure_const_age
+            ),
+            exposure_params.female_exposure_max,
+        )
+
     sex_age_exposure = np.where(
         sex_is_male,
         male_exposure_array,
@@ -60,4 +85,6 @@ def calculate_total_exposure(
     )
 
     total_exposure = sex_age_exposure * individual_exposure
+    if onchosim_exposure:
+        return total_exposure
     return total_exposure / np.mean(total_exposure)

--- a/epioncho_ibm/state/params.py
+++ b/epioncho_ibm/state/params.py
@@ -94,9 +94,7 @@ class BlackflyParams(BaseModel):
     l1_delay: float = 4  # (days)
     l3_delay: float = 10  # "l3.delay" (months) delay in worms entering humans and joining the first adult worm age class
 
-    immigrated_l3: float = (
-        0  # The number of worms that immigrated individuals will start with
-    )
+    immigrated_l3: float = 0  # A constant amount of L3 that will be added to the mean L3 in a single blackfly when calculating the larval release to humans
 
 
 class MicrofilParams(BaseModel):

--- a/epioncho_ibm/state/params.py
+++ b/epioncho_ibm/state/params.py
@@ -94,7 +94,7 @@ class BlackflyParams(BaseModel):
     l1_delay: float = 4  # (days)
     l3_delay: float = 10  # "l3.delay" (months) delay in worms entering humans and joining the first adult worm age class
 
-    immigrated_worm_count: int = (
+    immigrated_l3: float = (
         0  # The number of worms that immigrated individuals will start with
     )
 
@@ -120,6 +120,17 @@ class ExposureParams(BaseModel):
     male_exposure_exponent: float = 0.007  # "age.exp.m"
     female_exposure_exponent: float = -0.023  # "age.exp.f"
 
+    # ONCHOSIM Age-Sex Parameters:
+    male_exposure_max: float = 0  # onchosim age-sex maximum exposure for males
+    female_exposure_max: float = 0  # onchosim age-sex maximum exposure for females
+
+    male_exposure_const_age: float = (
+        20  # onchosim age where exposure for males becomes constant
+    )
+    female_exposure_const_age: float = (
+        20  # onchosim age where exposure for females becomes constant
+    )
+
 
 class HumanParams(BaseModel):
     min_skinsnip_age: int = 5
@@ -141,9 +152,7 @@ class BaseParams(BaseModel):
     year_length_days: float = 365
     month_length_days: float = 28
     sequela_active: SequelaType = []
-    immigration_rate: float = (
-        0  # The yearly rate at which people immigrate into the population
-    )
+    use_onchosim_mechanisms: str = ""  # Can be "" to not use any onchosim mechanisms "age-sex", "immigration" or "both"
 
 
 class BaseMutableParams(BaseParams):

--- a/epioncho_ibm/state/people.py
+++ b/epioncho_ibm/state/people.py
@@ -429,7 +429,9 @@ class People(HDF5Dataclass):
             return
 
         # using worm count
-        new_worms = blackfly_params.immigrated_worm_count
+        new_worms = np.random.poisson(
+            lam=blackfly_params.immigrated_worm_count, size=sum(people_to_immigrate)
+        )
 
         male_worms = worm_sex_ratio_generator.binomial(n=new_worms)
         self.worms.reset_population(people_to_immigrate)

--- a/epioncho_ibm/state/people.py
+++ b/epioncho_ibm/state/people.py
@@ -6,7 +6,7 @@ from numpy.random import SFC64, Generator
 
 from epioncho_ibm.utils import array_fully_equal
 
-from .params import BaseParams, BlackflyParams, Params, TreatmentParams
+from .params import Params, TreatmentParams
 from .types import Array
 
 
@@ -412,32 +412,6 @@ class People(HDF5Dataclass):
             corr, cov, size=len(self.ages), random_generator=numpy_bit_gen
         )
         self.compliance[np.argsort(self.compliance)] = np.sort(new_probs)
-
-    def immigration_check(
-        self,
-        blackfly_params: BlackflyParams,
-        immigration_rate: float,
-        delta_time: float,
-        worm_sex_ratio_generator: Generator,
-    ) -> bool:
-        total_pop = len(self.ages)
-        # Converting yearly rate to probability by timestep and conducting a trial
-        people_to_immigrate = np.random.random(total_pop) < (
-            1 - (1 - immigration_rate) ** delta_time
-        )
-        if sum(people_to_immigrate) == 0:
-            return
-
-        # using worm count
-        new_worms = np.random.poisson(
-            lam=blackfly_params.immigrated_worm_count, size=sum(people_to_immigrate)
-        )
-
-        male_worms = worm_sex_ratio_generator.binomial(n=new_worms)
-        self.worms.reset_population(people_to_immigrate)
-        self.worms.male[0, people_to_immigrate] = male_worms
-        self.worms.fertile[0, people_to_immigrate] = new_worms - male_worms
-        self.delay_arrays.process_deaths(people_to_immigrate, None)
 
     def process_deaths(
         self,


### PR DESCRIPTION
- Previously we were trying to implement our own immigration rather than resembling onchosim. This change reverses that, and implements "immigration" as a slight bump to the mean L3 that is used to calculate the number of larvae that will release from a blackfly to a human. This is defined by the parameter `immigrated_l3` in the BlackflyParams.

- This also implements ONCHOSIM's exposure function, which is a linear increase in exposure till age 20, and then a constant exposure till death. The exact values can be seen in figure 1 here: https://academic.oup.com/jid/article/221/Supplement_5/S510/5805561?login=false. The default parameters are set to match what is seen here. The parameters for this are `male_exposure_max`, `female_exposure_max`, `male_exposure_const_age`, and `female_exposure_const_age`. See the comments under the parameters for a description of what they do.

- An additional parameter was added that allows the modelers to turn on one or both of these different ONCHOSIM exposure mechanics, `use_onchosim_mechanisms`.

This has been tested using multiple values for `immigrated_l3`