### PR TITLE
Move to dev version for further development

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "epioncho-ibm"
-version = "1.0.0"
+version = "1.0.1dev"
 description = ""
 authors = ["mark-todd <markpeter.todd@hotmail.co.uk>"]
 


### PR DESCRIPTION
As per standard release process, move the version to a "dev" suffix one to make it clear this isn't a specific tagged version. 