### PR TITLE
Adding post processing function to tooly.py

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,10 @@
-Welcome to EPIONCHO-IBM
+# Welcome to EPIONCHO-IBM
+
+This is the Python version of the model, initiall developed in R: 
+
+The R model is described in full here, and should reflect the python model as well:
+Hamley JID, Milton P, Walker M, Basáñez MG Modelling exposure heterogeneity and density dependence in onchocerciasis using a novel individual-based transmission model, EPIONCHO-IBM: Implications for elimination and data needs. PLOS Neglected Tropical Diseases 2019; 13(12): e0007557. https://doi.org/10.1371/journal.pntd.0007557
+
 
 # Requirements
 

--- a/epioncho_ibm/tools.py
+++ b/epioncho_ibm/tools.py
@@ -1,6 +1,10 @@
 import csv
+import glob
 import math
 from collections import defaultdict
+
+import numpy as np
+import pandas as pd
 
 from epioncho_ibm import State
 
@@ -220,3 +224,193 @@ def write_data_to_csv(
         for row in rows:
             excel_data.append(row)
             writer.writerow(row)
+
+
+def post_processing_calculation(
+    data: list[Data],
+    iuName: str,
+    scenario: str,
+    csv_file: str,
+    mda_start_year: int = 2026,
+    mda_stop_year: int = 2041,
+    mda_interval: float = 1,
+) -> None:
+    """
+    Takes in non-age-grouped model outputs and generates a summarized output file that summarizes
+    the model outputs into mean, median, 2.5 percentile, and 97.5 percentile outputs.
+    It also calculates:
+        (for each year) the probability that < 1% mf prevalence was reached across all iterations/draws
+        (for each year) the probability that < 0% mf prevalence was reached across all iterations/draws
+        the year at which < 1% mf prevalence is reached, calculated using the average prevalence across all runs
+
+    Args:
+        data list[Data]: The raw data output from multiple runs of the model (a list of dictionaries, where each dictionary is the outputs for a single run of the model)
+        iuName str: A name to define the parameters used for the model, typically the name of the IU being simulated
+        scenario str: A name to define the scenario being tested
+        csv_file str: The name you want the post processed data to be saved to.
+        mda_start_year int: An optional variable to denote when MDA starts for a scenario
+        mda_stop_year int: An optional variable to denote when MDA ends for a given scenario
+        mda_interval int: An optional variable to denote the frequency of the MDA applied for a given scenario
+    """
+    # Arranging data into an easy to manipulate format (taken from tools.py)
+    data_combined_runs: dict[
+        tuple[float, float, float, str], list[float | int]
+    ] = defaultdict(list)
+    for run in data:
+        for k, v in run.items():
+            data_combined_runs[k].append(v)
+
+    rows = sorted(
+        (k + tuple(v) for k, v in data_combined_runs.items()),
+        key=lambda r: (r[0], r[3], r[1]),
+    )
+
+    tmp = np.array(rows)
+    # Data manipulation
+    # Calculating probability of elimination using mf_prev
+    mf_prev_mask = tmp[:, 3] == "prevalence"
+    mf_prev_vals = tmp[mf_prev_mask, 4:].astype(float)
+
+    # Probability of elimination for a given year = the average number of runs that reach 0 mf prev
+    prob_elim = np.mean(mf_prev_vals == 0, axis=1)
+    num_prob_elim = len(prob_elim)
+    none_array = np.full(num_prob_elim, None)
+    # combining results into a matrix format for output
+    prob_elim_output = np.column_stack(
+        (
+            tmp[mf_prev_mask, :3],
+            np.full(num_prob_elim, "prob_elim"),
+            prob_elim,
+            none_array,
+            none_array,
+            none_array,
+        )
+    )
+
+    # Calculating the year where each run has < 1% prev
+    mf_under_1_mask = mf_prev_vals < 0.01
+
+    # Probability of getting < 1% mfp for a given year
+    prob_under_1_mfp = np.mean(mf_under_1_mask, axis=1)
+    num_prob_under_1_mfp = len(prob_under_1_mfp)
+    none_array = np.full(num_prob_under_1_mfp, None)
+    prob_under_1_mfp_output = np.column_stack(
+        (
+            tmp[mf_prev_mask, :3],
+            np.full(num_prob_under_1_mfp, "prob_under_1_mfp"),
+            prob_under_1_mfp,
+            none_array,
+            none_array,
+            none_array,
+        )
+    )
+
+    # Calculating the year where the avg of all runs has < 1% mf prev
+    yearly_avg_mfp = np.mean(mf_prev_vals, axis=1)
+    indeces_of_1_mfp_avg = np.where(yearly_avg_mfp < 0.01)[0]
+    year_of_1_mfp_avg = None
+    if indeces_of_1_mfp_avg.size > 0:
+        year_of_1_mfp_avg = tmp[mf_prev_mask, :][indeces_of_1_mfp_avg[0], 0]
+    year_under_1_avg_mfp_output = np.column_stack(
+        (
+            "",
+            np.nan,
+            np.nan,
+            "year_of_1_mfp_avg",
+            year_of_1_mfp_avg,
+            None,
+            None,
+            None,
+        )
+    )
+
+    # Summarizing all other prevalence outputs
+    other_prevs = tmp[:, 4:].astype(float)
+    other_prevs_output = np.column_stack(
+        (
+            tmp[:, :4],
+            np.mean(other_prevs, axis=1),
+            np.percentile(other_prevs, 2.5, axis=1),
+            np.percentile(other_prevs, 97.5, axis=1),
+            np.median(other_prevs, axis=1),
+        )
+    )
+    output = np.row_stack(
+        (
+            other_prevs_output,
+            # probability of elim for each year
+            prob_elim_output,
+            # probability of 1% mf_prev for each year
+            prob_under_1_mfp_output,
+            # year_under_1_avg_mfp_output
+            year_under_1_avg_mfp_output,
+        )
+    )
+
+    descriptor_output = np.column_stack(
+        (
+            np.full(output.shape[0], iuName),
+            np.full(output.shape[0], scenario),
+            np.full(output.shape[0], mda_start_year),
+            np.full(output.shape[0], mda_stop_year),
+            np.full(output.shape[0], mda_interval),
+            output,
+        )
+    )
+
+    pd.DataFrame(
+        descriptor_output,
+        columns=[
+            "iu_name",
+            "scenario",
+            "mda_start_year",
+            "mda_stop_year",
+            "mda_interval",
+            "year_id",
+            "age_start",
+            "age_end",
+            "measure",
+            "mean",
+            "lower_bound",
+            "upper_bound",
+            "median",
+        ],
+    ).to_csv(csv_file)
+
+
+def combineAndFilter(
+    pathToOutputFiles=".",
+    specific_files="*.csv",
+    measure_filter=f'measure == "years_to_1_mfp" | measure == "rounds_to_1_mfp" | measure == "rounds_to_90_under_1_mfp" | measure == "years_to_90_under_1_mfp" | measure == "year_of_1_mfp_avg"',
+    output_file_root=".",
+):
+    """
+    Combines all data outputs in a given folder and filters as necessary. Saves it into two new files, one which is filtered, and one which is not.
+    The data in the folder should be the output of `post_processing_calculation`
+
+    Args:
+        pathToOutputFiles - where all the data files are located
+        specific_files - file name filter to only combine the files that are wanted
+        measure_filter - data filter that filters the values within each data file based. This is directly passed into `pd.query()`
+
+    """
+
+    rows = []
+    columns = []
+
+    for filename in glob.glob(
+        pathToOutputFiles + "**/" + specific_files, recursive=True
+    ):
+        with open(filename, newline="") as f:
+            reader = csv.reader(f)
+            if len(columns) == 0:
+                columns = next(reader)
+            else:
+                next(reader)
+            rows.extend(reader)
+
+    outputData = pd.DataFrame(rows, columns=columns)
+    outputData.to_csv(f"{output_file_root}-combined_data.csv")
+
+    filteredOutput = outputData.query(measure_filter)
+    filteredOutput.to_csv(f"{output_file_root}-combined_filtered_data.csv")

--- a/examples/simulation_template.py
+++ b/examples/simulation_template.py
@@ -6,7 +6,12 @@ from tqdm.contrib.concurrent import process_map
 
 from epioncho_ibm.endgame_simulation import EndgameSimulation
 from epioncho_ibm.state.params import EpionchoEndgameModel
-from epioncho_ibm.tools import Data, add_state_to_run_data, write_data_to_csv
+from epioncho_ibm.tools import (
+    Data,
+    add_state_to_run_data,
+    post_processing_calculation,
+    write_data_to_csv,
+)
 
 
 # You can edit the inputs to this function to set more parameters dynamically
@@ -102,14 +107,14 @@ def get_parameters(iter, abr=1641, kE=0.3):
             "initial": {
                 "n_people": 400,
                 "year_length_days": 365,
-                "delta_h_zero": 0.186,
-                "c_v": 0.005,
-                "delta_h_inf": 0.003,
                 "seed": seed,
                 "gamma_distribution": kE,
                 "delta_time_days": 1,
                 "blackfly": {
                     "bite_rate_per_person_per_year": abr,
+                    "delta_h_zero": 0.186,
+                    "c_v": 0.005,
+                    "delta_h_inf": 0.003,
                 },
                 "exposure": {"Q": 1.2},
                 # Having this in the parameters makes sure that sequela prevalence is calculated
@@ -265,6 +270,8 @@ if __name__ == "__main__":
     # from the all age outputs
     data: list[Data] = [row[0] for row in datas]
     age_data: list[Data] = [row[1] for row in datas]
+
+    post_processing_calculation(data, "tmpIU", "test", "post_processing_test.csv")
 
     # We are then going to save this data to a csv file
     write_data_to_csv(

--- a/examples/simulation_template.py
+++ b/examples/simulation_template.py
@@ -47,8 +47,8 @@ def get_parameters(iter, abr=1641, kE=0.3):
         }
     )
 
-    # Now we are adding 10 years of MDA [1994-2005)
-    # applied annually, at 65% total population coverage
+    # Now we are adding 20 years of MDA [1994-2015)
+    # applied bi-annually, at 80% total population coverage
     # We are also changing some of the parameters of
     # the effectiveness of the treatment
     # for a list of more parameters you can edit
@@ -61,11 +61,11 @@ def get_parameters(iter, abr=1641, kE=0.3):
     treatment_program.append(
         {
             "first_year": 1994,
-            "last_year": 2005,
+            "last_year": 2015,
             "interventions": {
                 "treatment_name": "MOX",
-                "treatment_interval": 1,
-                "total_population_coverage": 0.65,
+                "treatment_interval": 0.5,
+                "total_population_coverage": 0.80,
                 "correlation": 0.5,
                 "min_age_of_treatment": 4,
                 "microfilaricidal_nu": 0.04,
@@ -96,7 +96,7 @@ def get_parameters(iter, abr=1641, kE=0.3):
         }
     )
 
-    # The MDA applied from 1994 - 2005 also requires us to change the delta time parameter.
+    # The MDA applied from 1994 - 2015 also requires us to change the delta time parameter.
     # Here we make that change.
     changes.append({"year": 1994, "params": {"delta_time_days": 0.5}})
 
@@ -143,7 +143,7 @@ def run_simulations(
     abr=1641,
     kE=0.3,
     start_time=1900,
-    end_time=2005,
+    end_time=2015,
 ):
     endgame_structure = get_parameters(i, abr=abr, kE=kE)
 
@@ -271,7 +271,17 @@ if __name__ == "__main__":
     data: list[Data] = [row[0] for row in datas]
     age_data: list[Data] = [row[1] for row in datas]
 
-    post_processing_calculation(data, "tmpIU", "test", "post_processing_test.csv")
+    post_processing_calculation(
+        data=data,
+        iuName="tmpIU",
+        scenario="test",
+        prevalence_marker_name="prevalence",
+        csv_file="post_processing_test.csv",
+        post_processing_start_time=1970,
+        mda_start_year=1994,
+        mda_stop_year=2015,
+        mda_interval=0.5,
+    )
 
     # We are then going to save this data to a csv file
     write_data_to_csv(


### PR DESCRIPTION
For the endgame pipeline, a post processing function was developed to "prettify" the outputs of the model to be easily used for creating visualizationsm without much processing needing to be done manually. This PR will add this function to tools.py so it can be easily accessed by anyone using the model. 

This should capture the following:
- Prevalence summary - 2.5%, 5%, 25%, 50%, 75%, 90%, 95%, 97.5%, mean, SD
  - This is prevalence of the right age group and the right diagnostic for that particular disease (this sits with the scientific lead for each disease)
- which IUs which 90% of simulations the right measure of prevalence in the model (no survey applied) are below the threshold for that disease
  - Then at the country or Africa level the proportion of IUs for which this is true _**(this can be calculated across africa after combining all the individual post processed data)**_
- For LF and trachoma we will additionally output a marker for an IU having passed the final survey _**(this should be generalized enough to capture this within the `other_prevs` calculation)**_
- For SCH we need to think about the fact that the vaccine reduces output of eggs, so may have an additional prevalence output. _**(again, this should be generalized enough to capture this within the `other_prevs` calculation)**_

A description of the post processing can be found in the function header, but pasted below for easy reading: 

    Takes in non-age-grouped model outputs and generates a summarized output file that summarizes
    the model outputs into mean, median, standard deviation, 2.5, 5, 10, 25, 50, 75, 90, 95, and 97.5 percentiles.
    It also calculates:
        (for each year) the probability that < 1% mf prevalence was reached across all iterations/draws
        (for each year) the probability that < 0% mf prevalence was reached across all iterations/draws
        the year at which < 1% mf prevalence is reached, calculated using the average prevalence across all runs
        the year at which 90% of runs reach < 1% mf prevalence is reached

    Args:
        data list[Data]: The raw data output from multiple runs of the model (a list of dictionaries, where each dictionary is the outputs for a single run of the model)
        iuName str: A name to define the parameters used for the model, typically the name of the IU being simulated
        scenario str: A name to define the scenario being tested
        prevalence_marker_name str: The name for the prevalence marker to be used to calculate the additional outputs
        post_processing_start_time int: The time at which we start the calculations of reaching the threshold/elimination
        csv_file str: The name you want the post processed data to be saved to.
        mda_start_year int: An optional variable to denote when MDA starts for a scenario (for oncho specifically)
        mda_stop_year int: An optional variable to denote when MDA ends for a given scenario (for oncho specifically)
        mda_interval int: An optional variable to denote the frequency of the MDA applied for a given scenario (for oncho specifically)

- This PR also includes minor updates to the README and the template example file.
  