### PR TITLE
Shortening Automatic CI run time

### DIFF
--- a/.github/workflows/addComments.yml
+++ b/.github/workflows/addComments.yml
@@ -15,7 +15,7 @@ permissions:
 jobs:
     comment_on_pr:
         runs-on: ubuntu-latest
-        if: ${{ github.event.workflow_run.event == 'pull_request' && github.event.workflow_run.event == 'Testing Simulations' }}
+        if: ${{ github.event.workflow_run.event == 'pull_request' }}
         steps:
             - uses: actions/checkout@v3
               name: Get Comment File

--- a/.github/workflows/addComments.yml
+++ b/.github/workflows/addComments.yml
@@ -15,7 +15,7 @@ permissions:
 jobs:
     comment_on_pr:
         runs-on: ubuntu-latest
-        if: ${{ github.event.workflow_run.event == 'pull_request' }}
+        if: ${{ github.event.workflow_run.event == 'pull_request' && github.event.workflow_run.event == 'Testing Simulations' }}
         steps:
             - uses: actions/checkout@v3
               name: Get Comment File

--- a/.github/workflows/addComments.yml
+++ b/.github/workflows/addComments.yml
@@ -2,7 +2,7 @@ name: Adding Failure/Success Comment to PR
 
 on:
     workflow_run: 
-        workflows: ["Testing Simulations"]
+        workflows: ["End-to-End Test"]
         types: 
             - completed
 

--- a/.github/workflows/benchmarkForPR.yml
+++ b/.github/workflows/benchmarkForPR.yml
@@ -1,0 +1,47 @@
+# This workflow will install Python dependencies, run tests and lint with a single version of Python
+# For more information see: https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-python
+
+name: Running Benchmarks
+
+on:
+  push:
+    branches: 
+        - 'master'
+  pull_request:
+    branches:
+        - '*'
+
+permissions:
+  actions: read
+  contents: read
+  pull-requests: read
+  packages: read
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+    - name: Set up Python 3.10
+      uses: actions/setup-python@v3
+      with:
+        python-version: "3.10"
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip3 install flake8 poetry
+    - name: Setup Env with Poetry
+      run: |
+        poetry lock
+        poetry install
+    - name: Lint with flake8
+      run: |
+        # stop the build if there are Python syntax errors or undefined names
+        flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
+        # exit-zero treats all errors as warnings. The GitHub editor is 127 chars wide
+        flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
+    - name: Run Unit Tests
+      run: |
+        cd tests/
+        poetry run pytest
+        cd ../

--- a/.github/workflows/endToEndTest.yml
+++ b/.github/workflows/endToEndTest.yml
@@ -1,7 +1,7 @@
 # This workflow will install Python dependencies, run tests and lint with a single version of Python
 # For more information see: https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-python
 
-name: Testing Simulations
+name: End-to-End Test 
 
 on:
   push:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -45,11 +45,6 @@ jobs:
         flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
         # exit-zero treats all errors as warnings. The GitHub editor is 127 chars wide
         flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
-    - name: Run Unit Tests
-      run: |
-        cd tests/
-        poetry run pytest
-        cd ../
     - name: Run Base Model
       run: |
         poetry run python examples/testing_modules/test_new_changes.py

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -8,7 +8,7 @@ on:
     branches:
       - 'master'
   pull_request:
-    types: [labeled]
+    types: [labeled, synchronize]
 
 permissions:
   actions: read
@@ -18,7 +18,7 @@ permissions:
 
 jobs:
   build:
-    if: ${{ github.event_name == 'push' || (github.event_name == 'pull_request' && github.event.label.name == 'run end-to-end test') }}
+    if: ${{ github.event_name == 'push' || (github.event_name == 'pull_request' && github.event.pull_request.labels | length > 0 && contains(toJson(github.event.pull_request.labels.*.name), 'run end-to-end test')) }}
     runs-on: ubuntu-latest
     outputs:
       artifactId: ${{ steps.artifact-upload-step.outputs.artifact-id }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -18,7 +18,7 @@ permissions:
 
 jobs:
   build:
-    if: ${{ github.event_name == 'push' || (github.event_name == 'pull_request' && length(github.event.pull_request.labels) > 0 && contains(toJson(github.event.pull_request.labels.*.name), 'run end-to-end test')) }}
+    if: ${{ github.event_name == 'push' || (github.event_name == 'pull_request' && contains(toJson(github.event.pull_request.labels.*.name), 'run end-to-end test')) }}
     runs-on: ubuntu-latest
     outputs:
       artifactId: ${{ steps.artifact-upload-step.outputs.artifact-id }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -5,6 +5,7 @@ name: Testing Simulations
 
 on:
   push:
+    branches:
       - 'master'
   pull_request:
     types: [labeled]

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -18,7 +18,7 @@ permissions:
 
 jobs:
   build:
-    if: ${{ github.event_name == 'push' || (github.event_name == 'pull_request' && github.event.pull_request.labels | length > 0 && contains(toJson(github.event.pull_request.labels.*.name), 'run end-to-end test')) }}
+    if: ${{ github.event_name == 'push' || (github.event_name == 'pull_request' && length(github.event.pull_request.labels) > 0 && contains(toJson(github.event.pull_request.labels.*.name), 'run end-to-end test')) }}
     runs-on: ubuntu-latest
     outputs:
       artifactId: ${{ steps.artifact-upload-step.outputs.artifact-id }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -5,10 +5,9 @@ name: Testing Simulations
 
 on:
   push:
-    branches-ignore:
       - 'master'
   pull_request:
-    branches: [ "master" ]
+    types: [labeled]
 
 permissions:
   actions: read
@@ -18,6 +17,7 @@ permissions:
 
 jobs:
   build:
+    if: ${{ github.event_name == 'push' || (github.event_name == 'pull_request' && github.event.label.name == 'run end-to-end test') }}
     runs-on: ubuntu-latest
     outputs:
       artifactId: ${{ steps.artifact-upload-step.outputs.artifact-id }}


### PR DESCRIPTION
As per these issues (https://github.com/NTD-Modelling-Consortium/endgame-project/issues/75, https://github.com/NTD-Modelling-Consortium/endgame-project/issues/42, and https://github.com/NTD-Modelling-Consortium/endgame-project/issues/38), the EPIONCHO-IBM auto CI takes too long, as the full  end-to-end test requires 150 runs, and when running in the context of github actions doesn't use parallel processing. 

This PR changes the way the CI runs, with the automated CI for a PR only running the benchmark, which takes ~ 6 minutes. The full end-to-end test can be triggered on a PR by adding the "run end-to-end test" tag. 

Both these tests will also be run when code is pushed to the master branch.

tested on my own github repo, see https://github.com/adiramani/P_EPIONCHO-IBM/pull/14. 
